### PR TITLE
Not specifying arch and pull latest image

### DIFF
--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-[ "$architecture" == "amd64" ] && image=portainer/portainer:1.20.1
-[ "$architecture" == "i386" ]  && image=portainer/portainer:linux-386-1.20.1
-[ "$architecture" == "armhf" ] && image=portainer/portainer:linux-arm-1.20.1
-[ -z $image ] && ynh_die "Sorry, your $architecture architecture is not supported ..."
+#[ "$architecture" == "amd64" ] && image=portainer/portainer:1.20.1
+#[ "$architecture" == "i386" ]  && image=portainer/portainer:linux-386-1.20.1
+#[ "$architecture" == "armhf" ] && image=portainer/portainer:linux-arm-1.20.1
+#[ -z $image ] && ynh_die "Sorry, your $architecture architecture is not supported ..."
+
+image=portainer/portainer
 
 options="-p $port:9000 -v $data_path/data:/data -v /var/run/docker.sock:/var/run/docker.sock"
 containeroptions="--no-auth"


### PR DESCRIPTION
IMHO, there is no need to check arch as the arch will be automatically determined when pulling image (without specifying tag)
The use of recent portainer image resolves for me the unkown flag --no-auth error (issue #11)