### PR TITLE
Update run.sh to Portainer 1.23.0

### DIFF
--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-[ "$architecture" == "amd64" ] && image=portainer/portainer:1.20.1
-[ "$architecture" == "i386" ]  && image=portainer/portainer:linux-386-1.20.1
-[ "$architecture" == "armhf" ] && image=portainer/portainer:linux-arm-1.20.1
+[ "$architecture" == "amd64" ] && image=portainer/portainer:1.23.0
+[ "$architecture" == "i386" ]  && image=portainer/portainer:linux-386-1.23.0
+[ "$architecture" == "armhf" ] && image=portainer/portainer:linux-arm-1.23.0
 [ -z $image ] && ynh_die "Sorry, your $architecture architecture is not supported ..."
 
 options="-p $port:9000 -v $data_path/data:/data -v /var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
There is a bug in the current version of Portainer that causes any port mapping to fail. I needed to update the version to let me manually add ports through the UI. This small change seems to make Portainer for my case and I didn't notice any issues. More testing may be required.